### PR TITLE
Fix JSON key name in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,5 +70,5 @@ If your main branch doesn't call `main`, you can specify a custom one to compare
 curl -sS -X POST http://localhost:3000/api/projects/main-branch \
   -H "Authorization: Bearer storage_bootstrap_token" \
   -H "Content-Type: application/json" \
-  -d '{ "repo": "repo_name", "main-branch": "main_branch_name"}'
+  -d '{ "repo": "repo_name", "main_branch": "main_branch_name"}'
 ```


### PR DESCRIPTION
Proposing to fix typo in key name for the main branch selection endpoint.


### Context

Current README says the field is named `main-branch`, while in reality it should be `main_branch`

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-report-storage
