### PR TITLE
fix: honor PUBLIC_URL and X-Forwarded-Proto/Host when minting access tokens

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -67,6 +67,7 @@ export interface AppVariables {
   accessToken: string;
   fileStore: StaticFileStore;
   mainBranch: string;
+  publicUrl?: string;
   repositories: Repositories;
   retentionPolicy: RetentionPolicy;
   secret: string;
@@ -83,6 +84,12 @@ export interface AppContextOptions {
   accessToken: string;
   fileStore: StaticFileStore;
   mainBranch?: string;
+  /**
+   * Explicit public origin (e.g. "https://reports.example.com") embedded in
+   * minted access tokens. When unset, the origin is derived from the request,
+   * honoring X-Forwarded-Proto/X-Forwarded-Host set by a fronting proxy.
+   */
+  publicUrl?: string;
   repositories: Repositories;
   retentionPolicy?: RetentionPolicy;
   secret: string;
@@ -111,6 +118,7 @@ export type BuildHttpAppOptions<Bindings extends object = Record<string, never>>
 export type WorkerBindings = Omit<WorkerEnv, "ACCESS_TOKEN" | "MAIN_BRANCH" | "SECRET"> & {
   ACCESS_TOKEN?: string;
   MAIN_BRANCH?: string;
+  PUBLIC_URL?: string;
   R2_ASSETS_PREFIX?: string;
   R2_PREFIX?: string;
   R2_REPORTS_PREFIX?: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ const accessToken = process.env.ACCESS_TOKEN;
 const databasePath = process.env.DATABASE_PATH?.trim() || path.join(dataDir, "reports.sqlite");
 const mainBranch = process.env.MAIN_BRANCH?.trim() || "main";
 const secret = process.env.SECRET;
+const publicUrl = process.env.PUBLIC_URL?.trim() || undefined;
 const storageBackend = (process.env.STORAGE_BACKEND ?? process.env.STORAGE_TYPE ?? "fs").trim().toLowerCase();
 const retentionPolicy = parseRetentionPolicy((name) => process.env[name]);
 
@@ -181,7 +182,7 @@ const main = async (): Promise<void> => {
     reports: await SqliteReportRepository.create({ databasePath }),
   };
   const fileStore = createFileStore();
-  const app = await buildApp({ repositories, fileStore, accessToken, mainBranch, retentionPolicy, secret });
+  const app = await buildApp({ repositories, fileStore, accessToken, mainBranch, publicUrl, retentionPolicy, secret });
 
   startRetentionSweep({ fileStore, repositories });
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,3 +1,4 @@
+import type { Context } from "hono";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { logger } from "hono/logger";
@@ -102,6 +103,38 @@ const parseMultipartUploadBody = (
   };
 };
 
+const firstForwardedValue = (value: string | undefined): string | undefined =>
+  value?.split(",")[0]?.trim() || undefined;
+
+/**
+ * The origin embedded in minted access tokens. Behind a TLS-terminating
+ * proxy the raw request URL is the internal http:// origin, which bakes a
+ * broken url into every token (clients then get protocol-redirected and
+ * their POSTs method-downgraded). Precedence: explicit publicUrl option
+ * (PUBLIC_URL env) > X-Forwarded-Proto/X-Forwarded-Host > request origin.
+ */
+const resolvePublicOrigin = <Bindings extends object>(c: Context<AppEnv<Bindings>>): string => {
+  const configured = c.get("publicUrl");
+
+  if (configured) {
+    return new URL(configured).origin;
+  }
+
+  const requestUrl = new URL(c.req.url);
+  const forwardedHost = firstForwardedValue(c.req.header("x-forwarded-host"));
+  const forwardedProto = firstForwardedValue(c.req.header("x-forwarded-proto"));
+
+  if (forwardedHost) {
+    requestUrl.host = forwardedHost;
+  }
+
+  if (forwardedProto) {
+    requestUrl.protocol = `${forwardedProto}:`;
+  }
+
+  return requestUrl.origin;
+};
+
 export const createHttpApp = <Bindings extends object = Record<string, never>>(
   options: BuildHttpAppOptions<Bindings>,
 ) => {
@@ -118,6 +151,7 @@ export const createHttpApp = <Bindings extends object = Record<string, never>>(
     c.set("fileStore", appContext.fileStore);
     c.set("mainBranch", normalizeMainBranch(appContext.mainBranch));
     c.set("repositories", appContext.repositories);
+    c.set("publicUrl", appContext.publicUrl?.trim() || undefined);
     c.set("retentionPolicy", appContext.retentionPolicy ?? {});
     c.set("secret", requireEnvValue(appContext.secret, "SECRET"));
 
@@ -158,7 +192,7 @@ export const createHttpApp = <Bindings extends object = Record<string, never>>(
       return unauthorizedResponse(c);
     }
 
-    const url = new URL(c.req.url).origin;
+    const url = resolvePublicOrigin(c);
 
     const payload = {
       accessToken: createAccessTokenSecret(),

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -35,6 +35,7 @@ const createContext = async (env: WorkerBindings) => ({
     reportsPrefix: optionalString(env.R2_REPORTS_PREFIX),
   }),
   mainBranch: optionalString(env.MAIN_BRANCH),
+  publicUrl: optionalString(env.PUBLIC_URL),
   repositories: {
     accessTokens: await D1AccessTokenRepository.create({
       database: requiredBinding(env.REPORTS_DB, "REPORTS_DB"),

--- a/test/unit/api/token.spec.ts
+++ b/test/unit/api/token.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { buildApp } from "../../../src/app.js";
+import { SqliteAccessTokenRepository } from "../../../src/repositories/sqlite/accessTokens.js";
+import { SqliteProjectRepository } from "../../../src/repositories/sqlite/projects.js";
+import { SqliteReportRepository } from "../../../src/repositories/sqlite/reports.js";
+import { FsStore } from "../../../src/storage/fs.js";
+import { decodeAccessToken } from "../../../src/utils/accessToken.js";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const ACCESS_TOKEN = "test-bootstrap-token";
+const SECRET = "test-signing-secret";
+
+type TestApp = Awaited<ReturnType<typeof buildApp>>;
+
+const withApp = async (
+  run: (app: TestApp) => Promise<void>,
+  appOptions: Partial<Parameters<typeof buildApp>[0]> = {},
+) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "report-storage-token-test-"));
+  const app = await buildApp({
+    accessToken: ACCESS_TOKEN,
+    fileStore: new FsStore(path.join(tempDir, "files")),
+    repositories: {
+      accessTokens: await SqliteAccessTokenRepository.create({ databasePath: ":memory:" }),
+      projects: await SqliteProjectRepository.create({ databasePath: ":memory:" }),
+      reports: await SqliteReportRepository.create({ databasePath: ":memory:" }),
+    },
+    requestLogging: false,
+    secret: SECRET,
+    ...appOptions,
+  });
+
+  try {
+    await run(app);
+  } finally {
+    await app.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+};
+
+const mintTokenUrl = async (app: TestApp, headers: Record<string, string> = {}): Promise<string> => {
+  const response = await app.request("/api/token", {
+    headers: { authorization: `Bearer ${ACCESS_TOKEN}`, ...headers },
+    method: "POST",
+  });
+
+  expect(response.status).toBe(200);
+
+  const { access_token: accessToken } = (await response.json()) as { access_token: string };
+  const payload = await decodeAccessToken(accessToken, SECRET);
+
+  expect(payload).not.toBeNull();
+
+  return payload!.url;
+};
+
+describe("POST /api/token — embedded service url", () => {
+  it("uses the request origin when no proxy headers or publicUrl are present", async () => {
+    await withApp(async (app) => {
+      expect(await mintTokenUrl(app)).toBe("http://localhost");
+    });
+  });
+
+  it("honors X-Forwarded-Proto so tokens minted behind a TLS-terminating proxy embed https", async () => {
+    await withApp(async (app) => {
+      expect(await mintTokenUrl(app, { "x-forwarded-proto": "https" })).toBe("https://localhost");
+    });
+  });
+
+  it("honors X-Forwarded-Host alongside X-Forwarded-Proto", async () => {
+    await withApp(async (app) => {
+      expect(
+        await mintTokenUrl(app, {
+          "x-forwarded-host": "reports.example.com",
+          "x-forwarded-proto": "https",
+        }),
+      ).toBe("https://reports.example.com");
+    });
+  });
+
+  it("uses only the first value of comma-separated forwarded headers", async () => {
+    await withApp(async (app) => {
+      expect(
+        await mintTokenUrl(app, {
+          "x-forwarded-host": "reports.example.com, internal.proxy",
+          "x-forwarded-proto": "https, http",
+        }),
+      ).toBe("https://reports.example.com");
+    });
+  });
+
+  it("prefers an explicitly configured publicUrl over request origin and forwarded headers", async () => {
+    await withApp(
+      async (app) => {
+        expect(await mintTokenUrl(app, { "x-forwarded-proto": "http" })).toBe("https://reports.example.com");
+      },
+      { publicUrl: "https://reports.example.com/" },
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`POST /api/token` embeds `new URL(c.req.url).origin` — the **raw request origin** — in the minted token payload. Behind any TLS-terminating proxy (Cloudflare tunnel, nginx, ingress), that origin is the internal `http://` address, so every minted token carries a broken service URL.

The failure mode is nasty to diagnose: clients (e.g. the Allure CLI) derive every endpoint from the embedded URL, their `POST`s hit the proxy's https redirect, the 301 method-downgrades them to `GET`, and uploads fail with `404` — while `GET`s (history, ping) keep working, which masks the root cause. We hit this in production behind a Cloudflare tunnel and initially had to work around it by re-signing tokens out-of-band.

## Fix

The embedded origin now resolves with this precedence:

1. **`publicUrl` option / `PUBLIC_URL` env** — explicit override, the deterministic answer for any proxy topology;
2. **`X-Forwarded-Proto` / `X-Forwarded-Host`** — first value of comma-separated lists;
3. the raw request origin — unchanged behavior when neither is present, so unproxied deployments are unaffected.

Wired through both entry points: the node server reads `PUBLIC_URL` from the environment, and the Cloudflare worker accepts a `PUBLIC_URL` binding.

## Tests

`test/unit/api/token.spec.ts` (new) covers all three precedence levels, comma-list handling, and pins the unproxied default. Written red-first against the unpatched tree; full unit suite passes (47/47), `yarn build` and `yarn lint` clean.